### PR TITLE
Breaking changes to the `@id` directive

### DIFF
--- a/packages/graphql/src/classes/authorization/Neo4jGraphQLAuthorization.ts
+++ b/packages/graphql/src/classes/authorization/Neo4jGraphQLAuthorization.ts
@@ -47,10 +47,6 @@ export class Neo4jGraphQLAuthorization {
         this.authorization = authorization;
     }
 
-    public get globalAuthentication(): boolean {
-        return this.authorization.globalAuthentication || false;
-    }
-
     public async decode(
         context: Neo4jGraphQLContext | Neo4jGraphQLSubscriptionsConnectionParams
     ): Promise<JWTPayload | undefined> {

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -430,7 +430,6 @@ export interface Neo4jAuthorizationSettings {
     key: Key | ((context: Neo4jGraphQLContext) => Key);
     verify?: boolean;
     verifyOptions?: JWTVerifyOptions;
-    globalAuthentication?: boolean;
 }
 export interface RemoteJWKS {
     url: string | URL;


### PR DESCRIPTION
# Description

The `@id` directive has had a number of breaking changes.

The `autogenerate` argument has been removed. With this value set to `false`, the `@id` directive was essentially an alias for the `@unique` directive. Use the `@unique` directive instead.

The `unique` argument has been removed. We consider it necessary for a globally unique identifier to be backed by a unique node property constraint, so we have removed the ability to disable this. If you wish to automatically generate an ID without it being backed by a constraint, we recommend using the `@populatedBy` directive with a callback to generate appropriate values.

The `global` argument has been removed. This quite key feature of specifying the globally unique identifier for Relay was hidden away inside the `@id` directive. This functionality has been moved into its own directive, `@relayId`, which is used with no arguments. The use of the `@relayId` directive also implies that the field will be backed by a unique node property constraint.

Note, if using the `@id` and `@relayId` directive together on the same field, this will be an autogenerated ID compatible with Relay, and be backed by a single unique node property constraint. If you wish to give this constaint a name, use the `@unique` directive also with the `constraintName` argument.

## Complexity

Complexity: Medium
